### PR TITLE
Don't ignore files without ID in filename

### DIFF
--- a/InfectedRose.Triggers/TriggerDictionary.cs
+++ b/InfectedRose.Triggers/TriggerDictionary.cs
@@ -40,8 +40,6 @@ namespace InfectedRose.Triggers
                     {
                         if (int.TryParse(filePath, out fileId)) break;
                     }
-                    
-                    if (fileId == default) return;
 
                     await using var stream = File.OpenRead(entry);
 


### PR DESCRIPTION
Files like nd_ns_pet_ranch.lutriggers were skipped over with the previous code, as they don't end with a number, while they should just be interpreted as ID 0.