### PR TITLE
Use 1 and 0 in LegoDictionaryData.ToString()

### DIFF
--- a/InfectedRose.Builder.Behaviors/InfectedRose.Builder.Behaviors.csproj
+++ b/InfectedRose.Builder.Behaviors/InfectedRose.Builder.Behaviors.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Builder/InfectedRose.Builder.csproj
+++ b/InfectedRose.Builder/InfectedRose.Builder.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Core/HashMap.cs
+++ b/InfectedRose.Core/HashMap.cs
@@ -74,7 +74,7 @@ namespace InfectedRose.Core
 
             Marshal.StructureToPtr(obj, ptr, false);
             Marshal.Copy(ptr, buf, 0, size);
-            Marshal.FreeHGlobal(ptr)
+            Marshal.FreeHGlobal(ptr);
 
             return buf;
         }

--- a/InfectedRose.Core/HashMap.cs
+++ b/InfectedRose.Core/HashMap.cs
@@ -13,7 +13,7 @@ namespace InfectedRose.Core
         {
             Structure.Add(obj);
         }
-        
+
         public virtual byte[] Compile(Action<int> onData = default)
         {
             var compiled = new List<byte>();
@@ -23,7 +23,7 @@ namespace InfectedRose.Core
             foreach (var obj in Structure)
             {
                 onData?.Invoke(++index);
-                
+
                 switch (obj)
                 {
                     case null:
@@ -58,7 +58,7 @@ namespace InfectedRose.Core
 
             return compiled.ToArray();
         }
-        
+
         private static byte[] ToBytes(object obj)
         {
             if (!obj.GetType().IsValueType)
@@ -67,13 +67,14 @@ namespace InfectedRose.Core
 
                 return new byte[0];
             }
-            
+
             var size = Marshal.SizeOf(obj);
             var buf = new byte[size];
             var ptr = Marshal.AllocHGlobal(size);
 
             Marshal.StructureToPtr(obj, ptr, false);
             Marshal.Copy(ptr, buf, 0, size);
+            Marshal.FreeHGlobal(ptr)
 
             return buf;
         }
@@ -81,7 +82,7 @@ namespace InfectedRose.Core
         public static HashMap operator +(HashMap map, object obj)
         {
             map.Add(obj);
-            
+
             return map;
         }
     }

--- a/InfectedRose.Core/InfectedRose.Core.csproj
+++ b/InfectedRose.Core/InfectedRose.Core.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="RakDotNet.IO" Version="1.0.0" />
+      <PackageReference Include="RakDotNet.IO" Version="1.0.1" />
     </ItemGroup>
 
 </Project>

--- a/InfectedRose.Core/LegoDataDictionary.cs
+++ b/InfectedRose.Core/LegoDataDictionary.cs
@@ -191,6 +191,7 @@ namespace InfectedRose.Core
             {
                 var val = v switch
                 {
+                    bool boolean => boolean ? "1" : "0",
                     Vector2 vec2 => $"{vec2.X}{InfoSeparator}{vec2.Y}",
                     Vector3 vec3 => $"{vec3.X}{InfoSeparator}{vec3.Z}{InfoSeparator}{vec3.Y}",
                     Vector4 vec4 => $"{vec4.X}{InfoSeparator}{vec4.Z}{InfoSeparator}{vec4.Y}{InfoSeparator}{vec4.W}",

--- a/InfectedRose.Database/InfectedRose.Database.csproj
+++ b/InfectedRose.Database/InfectedRose.Database.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -15,6 +14,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.2" />
+      <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
       <PackageReference Include="System.Data.SqlClient" Version="4.3.0" />
     </ItemGroup>
 

--- a/InfectedRose.Geometry/InfectedRose.Geometry.csproj
+++ b/InfectedRose.Geometry/InfectedRose.Geometry.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Interface/InfectedRose.Interface.csproj
+++ b/InfectedRose.Interface/InfectedRose.Interface.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Luz/InfectedRose.Luz.csproj
+++ b/InfectedRose.Luz/InfectedRose.Luz.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Luz/LuzFile.cs
+++ b/InfectedRose.Luz/LuzFile.cs
@@ -142,7 +142,8 @@ namespace InfectedRose.Luz
             if (Version >= 0x26)
             {
                 SpawnPoint = reader.Read<Vector3>();
-                SpawnRotation = reader.Read<Quaternion>();
+                var spawnRotation = reader.Read<Quaternion>();
+                SpawnRotation = new Quaternion(spawnRotation.Y, spawnRotation.Z, spawnRotation.W, spawnRotation.X);
             }
 
             var sceneCount = Version < 0x25 ? reader.Read<byte>() : reader.Read<uint>();

--- a/InfectedRose.Lvl/InfectedRose.Lvl.csproj
+++ b/InfectedRose.Lvl/InfectedRose.Lvl.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Nif/InfectedRose.Nif.csproj
+++ b/InfectedRose.Nif/InfectedRose.Nif.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Pipeline/InfectedRose.Pipeline.csproj
+++ b/InfectedRose.Pipeline/InfectedRose.Pipeline.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Terrain/InfectedRose.Terrain.csproj
+++ b/InfectedRose.Terrain/InfectedRose.Terrain.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Triggers/InfectedRose.Triggers.csproj
+++ b/InfectedRose.Triggers/InfectedRose.Triggers.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Utilities/InfectedRose.Utilities.csproj
+++ b/InfectedRose.Utilities/InfectedRose.Utilities.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.World/InfectedRose.World.csproj
+++ b/InfectedRose.World/InfectedRose.World.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.World/WorldObject.cs
+++ b/InfectedRose.World/WorldObject.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Numerics;
 using System.Xml.Serialization;
+using InfectedRose.Core;
 using InfectedRose.Lvl;
 
 namespace InfectedRose.World


### PR DESCRIPTION
This pull request changes changes `bool`s in `LegoDictionaryData`s to use 1 and 0 for `true` and `false` when used with `ToString`.

Edit: This pull request now also includes a change to correct spawn rotations in the Luz files. The use case for this is unrelated.